### PR TITLE
Fix Control.Lens Hackage Link

### DIFF
--- a/src/FunctionSet.elm
+++ b/src/FunctionSet.elm
@@ -62,7 +62,7 @@ url : FunctionSet -> String
 url fs = case fs of
   HaskellPrelude -> "https://hackage.haskell.org/package/base/docs/Prelude.html"
   JustTraverse -> "https://hackage.haskell.org/package/base/docs/Prelude.html#v:traverse"
-  LensOperators -> "https://hackage.haskell.org/package/lens/docs/Control.Lens.html"
+  LensOperators -> "https://hackage.haskell.org/package/lens/docs/Control-Lens.html"
 
 mkFunctionUrl : FunctionSet -> String -> String
 mkFunctionUrl fs name = case fs of


### PR DESCRIPTION
It looks like the Hackage Link for the lens-operators set is using a `.` where it needs a `-`?

(as an aside, fantastic game, I've been loving it)