### PR TITLE
Reset the guesses state when changing the set

### DIFF
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -272,6 +272,9 @@ update msg model =
              (Just a, _) -> persist { state | functionSet = fs
                                             , answer = a
                                             , showFunctionSetPicker = False
+                                            , guesses = Dict.empty
+                                            , knownIdents = Set.empty
+                                            , knownChars = Set.empty
                                             }
              (Nothing, _) -> (Loaded state, Cmd.none)
          Nothing -> (Loaded state, Cmd.none)


### PR DESCRIPTION
In a middle of a game, when changing the set, this change
clears the guesses list and the known elements so that the
game start fresh.